### PR TITLE
feat(sidebar): add side menu and include in layout (issue #7)

### DIFF
--- a/CustomerManagementSystem/Views/Shared/_Layout.cshtml
+++ b/CustomerManagementSystem/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -30,10 +30,15 @@
             </div>
         </nav>
     </header>
-    <div class="container">
-        <main role="main" class="pb-3">
-            @RenderBody()
-        </main>
+    <div class="d-flex" style="min-height: calc(100vh - 120px);">
+        <div style="width: 220px;">
+            @await Html.PartialAsync("_SideMenu")
+        </div>
+        <div class="flex-grow-1 p-4">
+            <main role="main" class="pb-3">
+                @RenderBody()
+            </main>
+        </div>
     </div>
 
     <footer class="border-top footer text-muted">

--- a/CustomerManagementSystem/Views/Shared/_Layout.cshtml.css
+++ b/CustomerManagementSystem/Views/Shared/_Layout.cshtml.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
+/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {
@@ -41,6 +41,27 @@ button.accept-policy {
 
 .footer {
   position: absolute;
+  bottom: 0;
+  width: 100%;
+  white-space: nowrap;
+  line-height: 60px;
+}
+
+#side-menu {
+  min-height: 100vh;
+}
+
+#side-menu .nav-link {
+  color: #333;
+}
+
+#side-menu .nav-link:hover, #side-menu .nav-link.active {
+  background-color: #f8f9fa;
+  color: #1b6ec2;
+}
+
+.footer {
+  position: relative;
   bottom: 0;
   width: 100%;
   white-space: nowrap;

--- a/CustomerManagementSystem/Views/Shared/_SideMenu.cshtml
+++ b/CustomerManagementSystem/Views/Shared/_SideMenu.cshtml
@@ -1,0 +1,14 @@
+@* Side menu partial used across the application *@
+<nav id="side-menu" class="bg-light border-end">
+    <ul class="nav flex-column p-3">
+        <li class="nav-item mb-2">
+            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">Dashboard</a>
+        </li>
+        <li class="nav-item mb-2">
+            <a class="nav-link" asp-area="" asp-controller="Customer" asp-action="Index">Customer List</a>
+        </li>
+        <li class="nav-item mb-2">
+            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Privacy">Settings</a>
+        </li>
+    </ul>
+</nav>


### PR DESCRIPTION
Adds a reusable `_SideMenu` partial and includes it in the shared layout. Updates styles to support sidebar layout.

Linked issue: #7